### PR TITLE
Add private shadcn registry and gallery exporter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+.next
+out
+dist
+gallery/dist
+.DS_Store

--- a/gallery/.eslintrc.json
+++ b/gallery/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": ["next", "next/core-web-vitals"],
+  "rules": {
+    "@next/next/no-img-element": "off"
+  }
+}

--- a/gallery/README.md
+++ b/gallery/README.md
@@ -1,0 +1,21 @@
+# Gallery
+
+Next.js application that consumes the private shadcn-compatible registry and allows browsing,
+filtering, saving collections, and exporting component bundles via the official CLI.
+
+## Scripts
+
+```bash
+pnpm install
+pnpm dev
+```
+
+To run the export CLI by hand:
+
+```bash
+pnpm tsx tools/export-cli.ts \
+  --collection ./collections/ai-starter.json \
+  --registry http://localhost:3000/registry/index.json \
+  --template empty \
+  --pm pnpm
+```

--- a/gallery/app/(gallery)/_components/export-dialog.tsx
+++ b/gallery/app/(gallery)/_components/export-dialog.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import { useState, useTransition } from "react";
+
+import { runExportAction } from "../actions";
+
+export interface ExportDialogProps {
+  selected: string[];
+}
+
+export function ExportDialog({ selected }: ExportDialogProps) {
+  const [open, setOpen] = useState(false);
+  const [template, setTemplate] = useState<"empty" | "starter">("empty");
+  const [packageManager, setPackageManager] = useState<"pnpm" | "npm" | "yarn">("pnpm");
+  const [registryUrl, setRegistryUrl] = useState("http://localhost:3000/registry/index.json");
+  const [status, setStatus] = useState<string | null>(null);
+  const [result, setResult] = useState<{ outputDir: string; archivePath?: string; log: string } | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (selected.length === 0) {
+      setError("Select at least one component to export.");
+      return;
+    }
+    setError(null);
+    setStatus("Starting export...");
+    startTransition(async () => {
+      try {
+        const response = await runExportAction({
+          items: selected,
+          name: "Custom export",
+          registryUrl,
+          template,
+          packageManager,
+        });
+        setResult(response);
+        setStatus("Export completed");
+      } catch (cause) {
+        setError(cause instanceof Error ? cause.message : "Export failed");
+      }
+    });
+  }
+
+  async function handleCopy(value: string | undefined) {
+    if (!value) return;
+    await navigator.clipboard.writeText(value);
+    setStatus(`Copied path to clipboard: ${value}`);
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="rounded-full bg-primary px-3 py-2 text-sm font-medium text-primary-foreground disabled:opacity-50"
+        disabled={selected.length === 0}
+      >
+        Export selection
+      </button>
+      {open ? (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+          <div className="w-full max-w-2xl space-y-4 rounded-3xl border bg-background p-6 shadow-2xl">
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <h2 className="text-xl font-semibold">Export components</h2>
+                <p className="text-sm text-muted-foreground">
+                  We will scaffold a fresh Next.js app and install {selected.length} component{selected.length === 1 ? "" : "s"}.
+                </p>
+              </div>
+              <button type="button" onClick={() => setOpen(false)} className="text-sm text-muted-foreground">
+                Close
+              </button>
+            </div>
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div className="grid gap-4 md:grid-cols-2">
+                <label className="grid gap-1 text-sm">
+                  <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Base template</span>
+                  <select
+                    value={template}
+                    onChange={(event) => setTemplate(event.target.value as typeof template)}
+                    className="rounded-lg border px-3 py-2"
+                  >
+                    <option value="empty">Empty Next.js app</option>
+                    <option value="starter">Starter template</option>
+                  </select>
+                </label>
+                <label className="grid gap-1 text-sm">
+                  <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Package manager</span>
+                  <select
+                    value={packageManager}
+                    onChange={(event) => setPackageManager(event.target.value as typeof packageManager)}
+                    className="rounded-lg border px-3 py-2"
+                  >
+                    <option value="pnpm">pnpm</option>
+                    <option value="npm">npm</option>
+                    <option value="yarn">yarn</option>
+                  </select>
+                </label>
+                <label className="grid gap-1 text-sm md:col-span-2">
+                  <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Registry URL</span>
+                  <input
+                    value={registryUrl}
+                    onChange={(event) => setRegistryUrl(event.target.value)}
+                    required
+                    className="rounded-lg border px-3 py-2"
+                    placeholder="https://example.com/registry/index.json"
+                  />
+                </label>
+              </div>
+              <div className="rounded-2xl border bg-muted/30 p-4 text-sm">
+                <p className="mb-2 font-medium">Selected components</p>
+                <ul className="grid gap-1 text-muted-foreground">
+                  {selected.map((item) => (
+                    <li key={item}>{item}</li>
+                  ))}
+                </ul>
+              </div>
+              {error ? <p className="text-sm text-red-500">{error}</p> : null}
+              {status ? <p className="text-xs text-muted-foreground">{status}</p> : null}
+              <div className="flex items-center justify-end gap-2">
+                <button type="button" onClick={() => setOpen(false)} className="rounded-full px-3 py-2 text-sm">
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  className="rounded-full bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground disabled:opacity-50"
+                  disabled={isPending}
+                >
+                  {isPending ? "Exporting…" : "Run export"}
+                </button>
+              </div>
+            </form>
+            {result ? (
+              <div className="rounded-2xl border bg-muted/20 p-4 text-sm">
+                <h3 className="mb-2 font-semibold">Export ready</h3>
+                <p className="text-muted-foreground">
+                  Output directory: <code className="rounded bg-muted px-2 py-1">{result.outputDir}</code>
+                </p>
+                <div className="mt-3 flex flex-wrap gap-2">
+                  <button
+                    type="button"
+                    onClick={() => handleCopy(result.outputDir)}
+                    className="rounded-full border px-3 py-1 text-xs text-muted-foreground"
+                  >
+                    Copy folder path
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => handleCopy(result.archivePath)}
+                    className="rounded-full border px-3 py-1 text-xs text-muted-foreground"
+                    disabled={!result.archivePath}
+                  >
+                    Copy ZIP path
+                  </button>
+                  <a
+                    href="/api/export/zip"
+                    target="_blank"
+                    className="rounded-full border px-3 py-1 text-xs text-muted-foreground"
+                  >
+                    Download ZIP
+                  </a>
+                </div>
+                <details className="mt-3">
+                  <summary className="cursor-pointer text-xs text-muted-foreground">View logs</summary>
+                  <pre className="mt-2 max-h-48 overflow-auto rounded-lg bg-black/80 p-3 text-xs text-white">
+{result.log}
+                  </pre>
+                </details>
+              </div>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/gallery/app/(gallery)/_components/gallery-grid.tsx
+++ b/gallery/app/(gallery)/_components/gallery-grid.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useMemo } from "react";
+
+import type { GalleryItem } from "@/lib/catalog";
+import { resolvePreviewComponent } from "@/lib/preview-map";
+
+import { useSelection } from "./selection-context";
+
+export interface GalleryGridProps {
+  items: GalleryItem[];
+}
+
+export function GalleryGrid({ items }: GalleryGridProps) {
+  const { selected, toggle } = useSelection();
+
+  const countByCategory = useMemo(() => items.length, [items.length]);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold">Components</h1>
+        <span className="text-sm text-muted-foreground">
+          Showing {items.length} item{items.length === 1 ? "" : "s"} · {selected.length} selected
+        </span>
+      </div>
+      {countByCategory === 0 ? (
+        <div className="rounded-lg border border-dashed p-10 text-center text-sm text-muted-foreground">
+          Adjust your filters to find components.
+        </div>
+      ) : (
+        <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+          {items.map((item) => {
+            const Preview = resolvePreviewComponent(item.id);
+            const isSelected = selected.includes(item.id);
+
+            return (
+              <article key={item.id} className="flex flex-col overflow-hidden rounded-3xl border bg-background shadow-sm">
+                <div className="relative border-b bg-muted/40 p-4">
+                  {Preview ? (
+                    <div className="rounded-2xl border bg-background p-4">
+                      <Preview />
+                    </div>
+                  ) : (
+                    <div className="flex h-48 items-center justify-center text-sm text-muted-foreground">
+                      Preview unavailable
+                    </div>
+                  )}
+                </div>
+                <div className="flex flex-1 flex-col justify-between gap-4 p-5">
+                  <header className="space-y-2">
+                    <div className="flex items-center justify-between gap-3">
+                      <div>
+                        <h2 className="text-lg font-semibold">{item.name}</h2>
+                        <p className="text-xs uppercase tracking-wide text-muted-foreground">{item.type}</p>
+                      </div>
+                      <button
+                        type="button"
+                        onClick={() => toggle(item.id)}
+                        className={`rounded-full border px-3 py-1 text-xs font-medium transition ${isSelected ? "bg-primary text-primary-foreground" : "bg-muted/60 text-muted-foreground hover:bg-muted"}`}
+                      >
+                        {isSelected ? "Remove" : "Select"}
+                      </button>
+                    </div>
+                    {item.description ? <p className="text-sm text-muted-foreground">{item.description}</p> : null}
+                  </header>
+                  <div className="flex flex-wrap gap-2 text-xs">
+                    {(item.categories ?? []).map((category) => (
+                      <span key={category} className="rounded-full bg-muted px-3 py-1 text-muted-foreground">
+                        {category}
+                      </span>
+                    ))}
+                  </div>
+                  <footer className="flex flex-wrap items-center justify-between gap-3 text-xs text-muted-foreground">
+                    <div className="space-x-3">
+                      {item.dependencies && item.dependencies.length > 0 ? (
+                        <span>Deps: {item.dependencies.join(", ")}</span>
+                      ) : (
+                        <span>No runtime deps</span>
+                      )}
+                    </div>
+                    <span>License: {item.license?.type ?? "Custom"}</span>
+                  </footer>
+                </div>
+              </article>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default GalleryGrid;

--- a/gallery/app/(gallery)/_components/selection-context.tsx
+++ b/gallery/app/(gallery)/_components/selection-context.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { createContext, useContext, useMemo, useState } from "react";
+
+interface SelectionContextValue {
+  selected: string[];
+  toggle: (id: string) => void;
+  setSelection: (ids: string[]) => void;
+  clear: () => void;
+}
+
+const SelectionContext = createContext<SelectionContextValue | null>(null);
+
+export function SelectionProvider({ children }: { children: React.ReactNode }) {
+  const [selected, setSelected] = useState<string[]>([]);
+
+  const value = useMemo<SelectionContextValue>(
+    () => ({
+      selected,
+      toggle: (id: string) => {
+        setSelected((current) =>
+          current.includes(id) ? current.filter((item) => item !== id) : [...current, id]
+        );
+      },
+      setSelection: setSelected,
+      clear: () => setSelected([]),
+    }),
+    [selected]
+  );
+
+  return <SelectionContext.Provider value={value}>{children}</SelectionContext.Provider>;
+}
+
+export function useSelection() {
+  const context = useContext(SelectionContext);
+  if (!context) {
+    throw new Error("useSelection must be used within SelectionProvider");
+  }
+  return context;
+}

--- a/gallery/app/(gallery)/_components/sidebar-categories.tsx
+++ b/gallery/app/(gallery)/_components/sidebar-categories.tsx
@@ -1,0 +1,86 @@
+import Link from "next/link";
+
+import type { CatalogFacets } from "@/lib/catalog";
+
+function buildQuery(searchParams: URLSearchParams, key: string, value?: string) {
+  const next = new URLSearchParams(searchParams);
+  if (value) {
+    next.set(key, value);
+  } else {
+    next.delete(key);
+  }
+  next.delete("page");
+  const query = next.toString();
+  return query ? `?${query}` : "?";
+}
+
+export interface SidebarCategoriesProps {
+  facets: CatalogFacets;
+  searchParams: URLSearchParams;
+}
+
+export function SidebarCategories({ facets, searchParams }: SidebarCategoriesProps) {
+  const currentType = searchParams.get("type") ?? undefined;
+  const currentCategory = searchParams.get("cat") ?? undefined;
+
+  return (
+    <aside className="w-full max-w-xs space-y-8">
+      <section className="space-y-3">
+        <header>
+          <h2 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Types</h2>
+        </header>
+        <ul className="space-y-1 text-sm">
+          <li>
+            <Link
+              href={buildQuery(searchParams, "type")}
+              className={`flex items-center justify-between rounded-lg px-3 py-2 transition hover:bg-muted ${!currentType ? "bg-muted" : ""}`}
+            >
+              <span>All</span>
+              <span className="text-xs text-muted-foreground">{facets.types.reduce((sum, item) => sum + item.count, 0)}</span>
+            </Link>
+          </li>
+          {facets.types.map((type) => (
+            <li key={type.value}>
+              <Link
+                href={buildQuery(searchParams, "type", type.value)}
+                className={`flex items-center justify-between rounded-lg px-3 py-2 transition hover:bg-muted ${currentType === type.value ? "bg-muted" : ""}`}
+              >
+                <span>{type.label}</span>
+                <span className="text-xs text-muted-foreground">{type.count}</span>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </section>
+      <section className="space-y-3">
+        <header>
+          <h2 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Categories</h2>
+        </header>
+        <ul className="space-y-1 text-sm">
+          <li>
+            <Link
+              href={buildQuery(searchParams, "cat")}
+              className={`flex items-center justify-between rounded-lg px-3 py-2 transition hover:bg-muted ${!currentCategory ? "bg-muted" : ""}`}
+            >
+              <span>All</span>
+              <span className="text-xs text-muted-foreground">{facets.categories.reduce((sum, item) => sum + item.count, 0)}</span>
+            </Link>
+          </li>
+          {facets.categories.map((category) => (
+            <li key={category.value}>
+              <Link
+                href={buildQuery(searchParams, "cat", category.value)}
+                className={`flex items-center justify-between rounded-lg px-3 py-2 transition hover:bg-muted ${currentCategory === category.value ? "bg-muted" : ""}`}
+              >
+                <span>{category.label}</span>
+                <span className="text-xs text-muted-foreground">{category.count}</span>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </aside>
+  );
+}
+
+export default SidebarCategories;

--- a/gallery/app/(gallery)/_components/toolbar.tsx
+++ b/gallery/app/(gallery)/_components/toolbar.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useMemo, useState, useTransition } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+
+import type { CollectionDefinition } from "@/lib/catalog";
+
+import { saveCollectionAction } from "../actions";
+import { useSelection } from "./selection-context";
+import { ExportDialog } from "./export-dialog";
+
+export interface ToolbarProps {
+  collections: CollectionDefinition[];
+}
+
+export function Toolbar({ collections }: ToolbarProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const params = useSearchParams();
+  const { selected, setSelection } = useSelection();
+  const [search, setSearch] = useState(params.get("q") ?? "");
+  const [isSaving, startSaving] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const [saveOpen, setSaveOpen] = useState(false);
+
+  const collectionOptions = useMemo(() => collections, [collections]);
+
+  function handleSearchSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const next = new URLSearchParams(params.toString());
+    if (search) {
+      next.set("q", search);
+    } else {
+      next.delete("q");
+    }
+    router.push(`${pathname}?${next.toString()}`);
+  }
+
+  function handleCollectionChange(event: React.ChangeEvent<HTMLSelectElement>) {
+    const id = event.target.value;
+    if (!id) {
+      setSelection([]);
+      return;
+    }
+    const collection = collectionOptions.find((item) => item.id === id);
+    if (collection) {
+      setSelection(collection.items);
+    }
+  }
+
+  function handleSave(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+    const name = String(formData.get("name") ?? "");
+    const description = String(formData.get("description") ?? "");
+    setError(null);
+    startSaving(async () => {
+      try {
+        await saveCollectionAction({ name, description, items: selected });
+        setSaveOpen(false);
+      } catch (cause) {
+        setError(cause instanceof Error ? cause.message : "Unable to save collection.");
+      }
+    });
+  }
+
+  return (
+    <div className="flex flex-col gap-4 rounded-3xl border bg-background/80 p-6 shadow-sm">
+      <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <form onSubmit={handleSearchSubmit} className="flex w-full max-w-md items-center gap-2 rounded-full border px-4 py-2">
+          <input
+            type="search"
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+            placeholder="Search components"
+            className="flex-1 bg-transparent text-sm outline-none"
+          />
+          <button type="submit" className="text-sm font-medium text-primary">
+            Search
+          </button>
+        </form>
+        <div className="flex flex-wrap items-center gap-2">
+          <select
+            defaultValue=""
+            onChange={handleCollectionChange}
+            className="rounded-full border px-3 py-2 text-sm text-muted-foreground"
+          >
+            <option value="">Load collection</option>
+            {collectionOptions.map((collection) => (
+              <option key={collection.id} value={collection.id}>
+                {collection.name}
+              </option>
+            ))}
+          </select>
+          <button
+            type="button"
+            onClick={() => setSaveOpen(true)}
+            className="rounded-full border px-3 py-2 text-sm font-medium transition hover:bg-muted"
+            disabled={selected.length === 0}
+          >
+            Save collection
+          </button>
+          <ExportDialog selected={selected} />
+        </div>
+      </div>
+      {saveOpen ? (
+        <form onSubmit={handleSave} className="grid gap-3 rounded-2xl border bg-muted/40 p-4 text-sm">
+          <div className="flex items-center justify-between">
+            <h2 className="font-semibold">Save current selection</h2>
+            <button type="button" onClick={() => setSaveOpen(false)} className="text-xs text-muted-foreground">
+              Close
+            </button>
+          </div>
+          <label className="grid gap-1">
+            <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Name</span>
+            <input
+              name="name"
+              required
+              placeholder="New collection"
+              className="rounded-lg border px-3 py-2"
+            />
+          </label>
+          <label className="grid gap-1">
+            <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Description</span>
+            <textarea name="description" rows={3} className="rounded-lg border px-3 py-2" placeholder="Optional" />
+          </label>
+          {error ? <p className="text-xs text-red-500">{error}</p> : null}
+          <div className="flex items-center justify-end gap-2">
+            <button type="button" onClick={() => setSaveOpen(false)} className="rounded-full px-3 py-2 text-sm">
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="rounded-full bg-primary px-3 py-2 text-sm font-medium text-primary-foreground disabled:opacity-50"
+              disabled={isSaving || selected.length === 0}
+            >
+              {isSaving ? "Saving…" : "Save"}
+            </button>
+          </div>
+        </form>
+      ) : null}
+    </div>
+  );
+}

--- a/gallery/app/(gallery)/actions.ts
+++ b/gallery/app/(gallery)/actions.ts
@@ -1,0 +1,129 @@
+"use server";
+
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+import type { CollectionDefinition } from "@/lib/catalog";
+
+function slugify(input: string) {
+  return input
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)+/g, "");
+}
+
+export interface SaveCollectionInput {
+  name: string;
+  description?: string;
+  items: string[];
+  id?: string;
+}
+
+export async function saveCollectionAction(payload: SaveCollectionInput) {
+  const name = payload.name.trim();
+  if (!name) {
+    throw new Error("Collection name is required.");
+  }
+  const items = Array.from(new Set(payload.items));
+  if (items.length === 0) {
+    throw new Error("Select at least one component before saving.");
+  }
+
+  const id = payload.id ? slugify(payload.id) : slugify(name);
+  if (!id) {
+    throw new Error("Collection identifier could not be generated.");
+  }
+
+  const definition: CollectionDefinition = {
+    id,
+    name,
+    description: payload.description?.trim() || undefined,
+    items,
+  };
+
+  const targetPath = path.resolve(process.cwd(), "collections", `${id}.json`);
+  await fs.writeFile(targetPath, JSON.stringify(definition, null, 2));
+
+  return definition;
+}
+
+export interface RunExportInput {
+  items: string[];
+  name: string;
+  description?: string;
+  registryUrl: string;
+  template: "empty" | "starter";
+  packageManager: "pnpm" | "npm" | "yarn";
+}
+
+export interface RunExportResult {
+  outputDir: string;
+  log: string;
+  archivePath?: string;
+}
+
+export async function runExportAction(options: RunExportInput): Promise<RunExportResult> {
+  const { spawn } = await import("node:child_process");
+  const { once } = await import("node:events");
+  const cwd = path.resolve(process.cwd());
+  const tempCollection = {
+    id: "export-preview",
+    name: options.name,
+    description: options.description,
+    items: options.items,
+  } satisfies CollectionDefinition;
+  const tempPath = path.join(cwd, "collections", "__export-temp.json");
+  await fs.writeFile(tempPath, JSON.stringify(tempCollection, null, 2));
+  const args = [
+    "tools/export-cli.ts",
+    "--collection",
+    tempPath,
+    "--registry",
+    options.registryUrl,
+    "--template",
+    options.template,
+    "--pm",
+    options.packageManager,
+    "--force",
+  ];
+
+  const child = spawn("pnpm", ["tsx", ...args], {
+    cwd,
+    env: {
+      ...process.env,
+      REGISTRY_ROOT: process.env.REGISTRY_ROOT ?? path.resolve(cwd, "..", "ui-registry", "registry"),
+    },
+  });
+
+  let output = "";
+  child.stdout?.on("data", (chunk) => {
+    output += chunk.toString();
+  });
+  child.stderr?.on("data", (chunk) => {
+    output += chunk.toString();
+  });
+
+  const [code] = (await once(child, "exit")) as [number | null];
+  await fs.rm(tempPath, { force: true });
+  if (code !== 0) {
+    throw new Error(output || "Export failed");
+  }
+
+  const outputDir = path.resolve(cwd, "dist", "app");
+  const archivePath = path.join(path.resolve(cwd, "dist"), "app.zip");
+  try {
+    await fs.rm(archivePath, { force: true });
+    await new Promise<void>((resolve, reject) => {
+      const zip = spawn("zip", ["-r", archivePath, "app"], { cwd: path.join(cwd, "dist") });
+      zip.on("exit", (zipCode) => {
+        if (zipCode === 0) resolve();
+        else reject(new Error(`zip exited with code ${zipCode}`));
+      });
+      zip.on("error", reject);
+    });
+  } catch (error) {
+    console.warn("Unable to generate ZIP archive", error);
+  }
+
+  return { outputDir, log: output, archivePath };
+}

--- a/gallery/app/(gallery)/page.tsx
+++ b/gallery/app/(gallery)/page.tsx
@@ -1,0 +1,58 @@
+import { Suspense } from "react";
+
+import { buildFacets, filterItems, listCollections, loadRegistryItems } from "@/lib/catalog";
+
+import { GalleryGrid } from "./_components/gallery-grid";
+import { SidebarCategories } from "./_components/sidebar-categories";
+import { SelectionProvider } from "./_components/selection-context";
+import { Toolbar } from "./_components/toolbar";
+
+interface GalleryPageProps {
+  searchParams: Record<string, string | string[] | undefined>;
+}
+
+function toUrlSearchParams(searchParams: GalleryPageProps["searchParams"]) {
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(searchParams)) {
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        params.append(key, item);
+      }
+    } else if (typeof value === "string") {
+      params.set(key, value);
+    }
+  }
+  return params;
+}
+
+export default async function GalleryPage({ searchParams }: GalleryPageProps) {
+  const items = await loadRegistryItems();
+  const params = toUrlSearchParams(searchParams);
+  const activeType = params.get("type") ?? undefined;
+  const activeCategory = params.get("cat") ?? undefined;
+  const search = params.get("q") ?? undefined;
+
+  const filteredItems = filterItems(items, {
+    type: activeType,
+    category: activeCategory,
+    search,
+  });
+  const facets = buildFacets(items);
+  const collections = await listCollections();
+
+  return (
+    <SelectionProvider>
+      <div className="mx-auto flex max-w-7xl gap-10 px-6 py-12">
+        <div className="hidden shrink-0 md:block">
+          <SidebarCategories facets={facets} searchParams={params} />
+        </div>
+        <div className="flex-1 space-y-10">
+          <Toolbar collections={collections} />
+          <Suspense fallback={<div>Loading components…</div>}>
+            <GalleryGrid items={filteredItems} />
+          </Suspense>
+        </div>
+      </div>
+    </SelectionProvider>
+  );
+}

--- a/gallery/app/api/export/zip/route.ts
+++ b/gallery/app/api/export/zip/route.ts
@@ -1,0 +1,21 @@
+import { createReadStream } from "node:fs";
+import { stat } from "node:fs/promises";
+import path from "node:path";
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  const archivePath = path.resolve(process.cwd(), "dist", "app.zip");
+  try {
+    const fileStats = await stat(archivePath);
+    const stream = createReadStream(archivePath);
+    return new NextResponse(stream as any, {
+      headers: {
+        "Content-Type": "application/zip",
+        "Content-Length": String(fileStats.size),
+        "Content-Disposition": 'attachment; filename="exported-app.zip"',
+      },
+    });
+  } catch (error) {
+    return NextResponse.json({ error: "Archive not found" }, { status: 404 });
+  }
+}

--- a/gallery/app/globals.css
+++ b/gallery/app/globals.css
@@ -1,0 +1,22 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --background: 0 0% 100%;
+  --foreground: 224 71% 4%;
+  --muted: 220 14% 96%;
+  --muted-foreground: 220 8% 45%;
+  --secondary: 220 14% 96%;
+  --secondary-foreground: 220 14% 25%;
+  --primary: 262 83% 58%;
+  --primary-foreground: 210 20% 98%;
+  --border: 220 13% 91%;
+  --input: 220 13% 91%;
+  --ring: 262 83% 58%;
+  --radius: 0.75rem;
+}
+
+body {
+  @apply bg-background text-foreground antialiased;
+}

--- a/gallery/app/layout.tsx
+++ b/gallery/app/layout.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from "next";
+import { Inter } from "next/font/google";
+import "./globals.css";
+
+const inter = Inter({ subsets: ["latin"], variable: "--font-inter" });
+
+export const metadata: Metadata = {
+  title: "UI Registry Gallery",
+  description: "Browse and export private shadcn-compatible components.",
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en" className={inter.variable}>
+      <body className="min-h-screen bg-background text-foreground">
+        <main className="min-h-screen">{children}</main>
+      </body>
+    </html>
+  );
+}

--- a/gallery/collections/ai-starter.json
+++ b/gallery/collections/ai-starter.json
@@ -1,0 +1,6 @@
+{
+  "id": "ai-starter",
+  "name": "AI Starter Collection",
+  "description": "Chat interface essentials for rapid prototyping.",
+  "items": ["ai-chat-window", "ai-message-list", "ai-input", "auth-dropdown"]
+}

--- a/gallery/lib/catalog.ts
+++ b/gallery/lib/catalog.ts
@@ -1,0 +1,169 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+export interface RegistryIndexItem {
+  id: string;
+  name: string;
+  type: string;
+  categories?: string[];
+  meta: string;
+}
+
+export interface RegistryIndex {
+  registry: string;
+  version: number;
+  items: RegistryIndexItem[];
+}
+
+export interface RegistryFileDescriptor {
+  src: string;
+  dest: string;
+  type: string;
+}
+
+export interface RegistryMeta {
+  id: string;
+  name: string;
+  type: string;
+  description?: string;
+  categories?: string[];
+  files: RegistryFileDescriptor[];
+  preview?: {
+    src: string;
+  };
+  dependencies?: string[];
+  peerDependencies?: Record<string, string>;
+  license?: {
+    type: string;
+    url?: string;
+  };
+}
+
+export interface GalleryItem extends RegistryMeta {
+  previewPath?: string;
+}
+
+const REGISTRY_ROOT = process.env.REGISTRY_ROOT
+  ? path.resolve(process.env.REGISTRY_ROOT)
+  : path.resolve(process.cwd(), "..", "ui-registry", "registry");
+
+async function readJsonFile<T>(filePath: string): Promise<T> {
+  const data = await fs.readFile(filePath, "utf8");
+  return JSON.parse(data) as T;
+}
+
+export async function loadRegistryIndex(): Promise<RegistryIndex> {
+  const indexPath = path.join(REGISTRY_ROOT, "index.json");
+  return readJsonFile<RegistryIndex>(indexPath);
+}
+
+export async function loadRegistryItems(): Promise<GalleryItem[]> {
+  const index = await loadRegistryIndex();
+  const items = await Promise.all(
+    index.items.map(async (item) => {
+      const metaPath = path.resolve(REGISTRY_ROOT, item.meta);
+      const meta = await readJsonFile<RegistryMeta>(metaPath);
+      return {
+        ...meta,
+        previewPath: meta.preview ? path.resolve(path.dirname(metaPath), meta.preview.src) : undefined,
+      } satisfies GalleryItem;
+    })
+  );
+  return items;
+}
+
+export interface FilterOptions {
+  type?: string;
+  category?: string;
+  search?: string;
+}
+
+export function filterItems(items: GalleryItem[], options: FilterOptions): GalleryItem[] {
+  const { type, category, search } = options;
+  return items.filter((item) => {
+    if (type && item.type !== type) {
+      return false;
+    }
+    if (category && !(item.categories ?? []).includes(category)) {
+      return false;
+    }
+    if (search) {
+      const haystack = `${item.name} ${item.description ?? ""}`.toLowerCase();
+      if (!haystack.includes(search.toLowerCase())) {
+        return false;
+      }
+    }
+    return true;
+  });
+}
+
+export interface FacetCount {
+  label: string;
+  value: string;
+  count: number;
+}
+
+export interface CatalogFacets {
+  types: FacetCount[];
+  categories: FacetCount[];
+}
+
+export function buildFacets(items: GalleryItem[]): CatalogFacets {
+  const typeMap = new Map<string, number>();
+  const categoryMap = new Map<string, number>();
+
+  for (const item of items) {
+    typeMap.set(item.type, (typeMap.get(item.type) ?? 0) + 1);
+    for (const category of item.categories ?? []) {
+      categoryMap.set(category, (categoryMap.get(category) ?? 0) + 1);
+    }
+  }
+
+  return {
+    types: Array.from(typeMap.entries()).map(([value, count]) => ({
+      label: value.replace(/^[a-z]/, (letter) => letter.toUpperCase()),
+      value,
+      count,
+    })),
+    categories: Array.from(categoryMap.entries())
+      .map(([value, count]) => ({
+        label: value.replace(/(^|\s)([a-z])/g, (_, space, letter) => `${space}${letter.toUpperCase()}`),
+        value,
+        count,
+      }))
+      .sort((a, b) => a.label.localeCompare(b.label)),
+  };
+}
+
+export interface CollectionDefinition {
+  id: string;
+  name: string;
+  description?: string;
+  items: string[];
+}
+
+export async function listCollections(): Promise<CollectionDefinition[]> {
+  const collectionsDir = path.resolve(process.cwd(), "collections");
+  let files: string[] = [];
+  try {
+    files = await fs.readdir(collectionsDir);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return [];
+    }
+    throw error;
+  }
+  const jsonFiles = files.filter((file) => file.endsWith(".json"));
+  const collections = await Promise.all(
+    jsonFiles.map(async (file) => {
+      const filePath = path.join(collectionsDir, file);
+      return readJsonFile<CollectionDefinition>(filePath);
+    })
+  );
+  return collections;
+}
+
+export async function loadCollectionById(id: string): Promise<CollectionDefinition | undefined> {
+  const collections = await listCollections();
+  return collections.find((collection) => collection.id === id);
+}

--- a/gallery/lib/preview-map.ts
+++ b/gallery/lib/preview-map.ts
@@ -1,0 +1,33 @@
+import dynamic from "next/dynamic";
+import type { ComponentType } from "react";
+
+type PreviewResolver = () => Promise<{ default: ComponentType } | ComponentType>;
+
+type PreviewMap = Record<string, PreviewResolver>;
+
+const previewResolvers: PreviewMap = {
+  "ai-chat-window": () => import("@registry/ai-chat-window/src/ai-chat-window.preview"),
+  "ai-message-list": () => import("@registry/ai-message-list/src/ai-message-list.preview"),
+  "ai-input": () => import("@registry/ai-input/src/ai-input.preview"),
+  "command-menu": () => import("@registry/command-menu/src/command-menu.preview"),
+  "pricing-card": () => import("@registry/pricing-card/src/pricing-card.preview"),
+  "auth-dropdown": () => import("@registry/auth-dropdown/src/auth-dropdown.preview"),
+};
+
+export function resolvePreviewComponent(id: string) {
+  const resolver = previewResolvers[id];
+  if (!resolver) {
+    return null;
+  }
+
+  return dynamic(async () => {
+    const module = await resolver();
+    if ("default" in module && module.default) {
+      return module.default as ComponentType;
+    }
+    return module as unknown as ComponentType;
+  }, {
+    loading: () => <div className="flex h-48 items-center justify-center text-sm text-muted-foreground">Loading preview…</div>,
+    ssr: false,
+  });
+}

--- a/gallery/next-env.d.ts
+++ b/gallery/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/gallery/next.config.js
+++ b/gallery/next.config.js
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    typedRoutes: true,
+    externalDir: true,
+  },
+};
+
+module.exports = nextConfig;

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "gallery",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "export:collection": "tsx tools/export-cli.ts"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "20.12.7",
+    "@types/react": "18.2.64",
+    "@types/react-dom": "18.2.21",
+    "autoprefixer": "10.4.16",
+    "eslint": "8.57.0",
+    "eslint-config-next": "14.2.3",
+    "postcss": "8.4.33",
+    "tailwindcss": "3.4.3",
+    "tsx": "4.7.0",
+    "typescript": "5.4.5"
+  }
+}

--- a/gallery/postcss.config.js
+++ b/gallery/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/gallery/tailwind.config.ts
+++ b/gallery/tailwind.config.ts
@@ -1,0 +1,40 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: [
+    "./app/**/*.{ts,tsx}",
+    "./components/**/*.{ts,tsx}",
+    "./lib/**/*.{ts,tsx}",
+  ],
+  theme: {
+    extend: {
+      colors: {
+        border: "hsl(var(--border))",
+        input: "hsl(var(--input))",
+        ring: "hsl(var(--ring))",
+        background: "hsl(var(--background))",
+        foreground: "hsl(var(--foreground))",
+        primary: {
+          DEFAULT: "hsl(var(--primary))",
+          foreground: "hsl(var(--primary-foreground))",
+        },
+        secondary: {
+          DEFAULT: "hsl(var(--secondary))",
+          foreground: "hsl(var(--secondary-foreground))",
+        },
+        muted: {
+          DEFAULT: "hsl(var(--muted))",
+          foreground: "hsl(var(--muted-foreground))",
+        },
+      },
+      borderRadius: {
+        lg: "var(--radius)",
+        md: "calc(var(--radius) - 2px)",
+        sm: "calc(var(--radius) - 4px)",
+      },
+    },
+  },
+  plugins: [],
+};
+
+export default config;

--- a/gallery/templates/starter/README.md
+++ b/gallery/templates/starter/README.md
@@ -1,0 +1,3 @@
+# Starter template
+
+Placeholder starter template for the export CLI. Replace with your own project files.

--- a/gallery/tools/export-cli.ts
+++ b/gallery/tools/export-cli.ts
@@ -1,0 +1,258 @@
+#!/usr/bin/env tsx
+/*
+ * Export selected registry items into a fresh Next.js application by invoking the shadcn CLI.
+ */
+
+import { spawn } from "node:child_process";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+interface CliOptions {
+  collectionPath: string;
+  registryUrl: string;
+  template: "empty" | "starter";
+  packageManager: "pnpm" | "npm" | "yarn";
+  force?: boolean;
+}
+
+interface CollectionFile {
+  id: string;
+  name: string;
+  description?: string;
+  items: string[];
+}
+
+interface RegistryIndexItem {
+  id: string;
+  meta: string;
+}
+
+interface RegistryIndex {
+  items: RegistryIndexItem[];
+}
+
+interface RegistryMetaFile {
+  id: string;
+  name: string;
+  files: Array<{ dest: string }>;
+  license?: { type: string; url?: string };
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  const args = [...argv];
+  const options: Partial<CliOptions> = {};
+
+  while (args.length) {
+    const arg = args.shift();
+    if (!arg) continue;
+    switch (arg) {
+      case "--collection":
+        options.collectionPath = args.shift() ?? "";
+        break;
+      case "--registry":
+        options.registryUrl = args.shift() ?? "";
+        break;
+      case "--template":
+        options.template = (args.shift() as CliOptions["template"]) ?? "empty";
+        break;
+      case "--pm":
+        options.packageManager = (args.shift() as CliOptions["packageManager"]) ?? "pnpm";
+        break;
+      case "--force":
+        options.force = true;
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!options.collectionPath) {
+    throw new Error("Missing --collection option.");
+  }
+  if (!options.registryUrl) {
+    throw new Error("Missing --registry option.");
+  }
+
+  return {
+    collectionPath: options.collectionPath,
+    registryUrl: options.registryUrl,
+    template: options.template ?? "empty",
+    packageManager: options.packageManager ?? "pnpm",
+    force: options.force ?? false,
+  };
+}
+
+async function readJsonFile<T>(filePath: string): Promise<T> {
+  const data = await readFile(filePath, "utf8");
+  return JSON.parse(data) as T;
+}
+
+async function runCommand(command: string, args: string[], options: { cwd: string }): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      stdio: "inherit",
+      shell: process.platform === "win32",
+    });
+    child.on("exit", (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`${command} exited with code ${code}`));
+      }
+    });
+    child.on("error", reject);
+  });
+}
+
+async function ensureCleanDirectory(targetDir: string, force: boolean) {
+  try {
+    await rm(targetDir, { recursive: true, force: true });
+  } catch (error) {
+    if (!force) {
+      throw error;
+    }
+  }
+  await mkdir(targetDir, { recursive: true });
+}
+
+async function scaffoldTemplate(baseDir: string, template: CliOptions["template"], packageManager: CliOptions["packageManager"]) {
+  if (template === "empty") {
+    await runCommand("npx", [
+      "create-next-app@latest",
+      baseDir,
+      "--ts",
+      "--eslint",
+      "--tailwind",
+      "--app",
+      "--src-dir",
+      "--import-alias",
+      "@/*",
+      "--no-install",
+    ], { cwd: process.cwd() });
+    return;
+  }
+
+  if (template === "starter") {
+    const templateDir = path.resolve(process.cwd(), "templates", "starter");
+    await mkdir(baseDir, { recursive: true });
+    await runCommand("cp", ["-R", `${templateDir}/.`, baseDir], { cwd: process.cwd() });
+    if (packageManager === "pnpm") {
+      await runCommand("pnpm", ["install"], { cwd: baseDir });
+    } else if (packageManager === "npm") {
+      await runCommand("npm", ["install"], { cwd: baseDir });
+    } else {
+      await runCommand("yarn", [], { cwd: baseDir });
+    }
+    return;
+  }
+
+  throw new Error(`Unsupported template: ${template}`);
+}
+
+async function initShadcn(appDir: string) {
+  await runCommand("npx", ["shadcn@latest", "init", "-y"], { cwd: appDir });
+}
+
+async function installBaseDependencies(appDir: string, manager: CliOptions["packageManager"]) {
+  const packages = ["lucide-react"];
+  if (packages.length === 0) return;
+  if (manager === "pnpm") {
+    await runCommand("pnpm", ["add", ...packages], { cwd: appDir });
+    return;
+  }
+  if (manager === "npm") {
+    await runCommand("npm", ["install", ...packages], { cwd: appDir });
+    return;
+  }
+  await runCommand("yarn", ["add", ...packages], { cwd: appDir });
+}
+
+async function addComponents(appDir: string, registryUrl: string, items: string[]) {
+  if (items.length === 0) {
+    throw new Error("No components selected for export.");
+  }
+  await runCommand("npx", ["shadcn@latest", "add", "--registry", registryUrl, ...items], { cwd: appDir });
+}
+
+async function loadRegistryMeta(registryRoot: string, itemId: string) {
+  const index = await readJsonFile<RegistryIndex>(path.join(registryRoot, "index.json"));
+  const record = index.items.find((item) => item.id === itemId);
+  if (!record) {
+    throw new Error(`Item '${itemId}' not found in registry index.`);
+  }
+  const metaPath = path.resolve(registryRoot, record.meta);
+  return readJsonFile<RegistryMetaFile>(metaPath);
+}
+
+async function validateFiles(appDir: string, registryRoot: string, items: string[]) {
+  const missing: Array<{ itemId: string; file: string }> = [];
+  for (const itemId of items) {
+    const meta = await loadRegistryMeta(registryRoot, itemId);
+    for (const file of meta.files) {
+      const targetPath = path.join(appDir, file.dest);
+      try {
+        await readFile(targetPath, "utf8");
+      } catch {
+        missing.push({ itemId, file: file.dest });
+      }
+    }
+  }
+  if (missing.length > 0) {
+    const message = missing
+      .map((entry) => `• ${entry.itemId} → ${entry.file}`)
+      .join("\n");
+    throw new Error(`Some files were not generated:\n${message}`);
+  }
+}
+
+async function generateLicenseSummary(appDir: string, registryRoot: string, items: string[]) {
+  const lines = ["# Component licenses", ""];
+  lines.push("| Item | License | Source |");
+  lines.push("| --- | --- | --- |");
+  const seen = new Set<string>();
+
+  for (const itemId of items) {
+    const meta = await loadRegistryMeta(registryRoot, itemId);
+    if (seen.has(itemId)) continue;
+    seen.add(itemId);
+    const license = meta.license?.type ?? "Custom";
+    const source = meta.license?.url ?? "—";
+    lines.push(`| ${meta.name ?? itemId} | ${license} | ${source} |`);
+  }
+
+  await writeFile(path.join(appDir, "LICENSES.md"), `${lines.join("\n")}\n`, "utf8");
+}
+
+async function writeSummaryReadme(appDir: string, collection: CollectionFile, registryUrl: string, options: CliOptions) {
+  const content = `# Export summary\n\n- Source collection: **${collection.name}** (${collection.id})\n- Registry: ${registryUrl}\n- Components installed: ${collection.items.join(", ")}\n- Package manager: ${options.packageManager}\n\n## Next steps\n\n1. Install dependencies (if not already):\n   \`${options.packageManager} install\`\n2. Start the dev server:\n   \`${options.packageManager} dev\`\n3. Configure any required environment variables (AI keys, etc.).\n`;
+  await writeFile(path.join(appDir, "REGISTRY_EXPORT.md"), content, "utf8");
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const collection = await readJsonFile<CollectionFile>(path.resolve(options.collectionPath));
+  const registryRoot = process.env.REGISTRY_ROOT
+    ? path.resolve(process.env.REGISTRY_ROOT)
+    : path.resolve(process.cwd(), "..", "ui-registry", "registry");
+
+  const distDir = path.resolve(process.cwd(), "dist");
+  const appDir = path.join(distDir, "app");
+  await ensureCleanDirectory(distDir, options.force ?? false);
+
+  await scaffoldTemplate(appDir, options.template, options.packageManager);
+
+  await initShadcn(appDir);
+  await installBaseDependencies(appDir, options.packageManager);
+  await addComponents(appDir, options.registryUrl, collection.items);
+  await validateFiles(appDir, registryRoot, collection.items);
+  await generateLicenseSummary(appDir, registryRoot, collection.items);
+  await writeSummaryReadme(appDir, collection, options.registryUrl, options);
+
+  console.log(`\n✔ Export completed successfully in ${appDir}`);
+}
+
+main().catch((error) => {
+  console.error("Export failed:", error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/gallery/tsconfig.json
+++ b/gallery/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node"],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"],
+      "@registry/*": ["../ui-registry/registry/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/ui-registry/README.md
+++ b/ui-registry/README.md
@@ -1,0 +1,16 @@
+# UI Registry
+
+This repository contains a private registry compatible with the `shadcn/ui` CLI.
+
+## Usage
+
+Install components directly from the registry by pointing the CLI at the raw
+`index.json` file:
+
+```bash
+npx shadcn@latest add --registry <REGISTRY_URL>/registry/index.json <component-id>
+```
+
+Each component ships with normalized destinations for `components` and `lib`
+folders, and includes dependency metadata so the CLI can install peer and runtime
+dependencies automatically.

--- a/ui-registry/registry/ai-chat-window/meta.json
+++ b/ui-registry/registry/ai-chat-window/meta.json
@@ -1,0 +1,29 @@
+{
+  "id": "ai-chat-window",
+  "name": "AI Chat Window",
+  "type": "component",
+  "categories": ["ai", "chat"],
+  "description": "Full chat surface with header, streaming indicator, and message composer.",
+  "files": [
+    {
+      "src": "src/ai-chat-window.tsx",
+      "dest": "components/ai/chat-window.tsx",
+      "type": "component"
+    }
+  ],
+  "preview": {
+    "src": "src/ai-chat-window.preview.tsx"
+  },
+  "dependencies": [
+    "lucide-react"
+  ],
+  "peerDependencies": {
+    "react": ">=18.2.0",
+    "next": ">=13.4.0",
+    "ai": ">=2.2.0"
+  },
+  "license": {
+    "type": "MIT",
+    "url": "https://opensource.org/licenses/MIT"
+  }
+}

--- a/ui-registry/registry/ai-chat-window/src/ai-chat-window.preview.tsx
+++ b/ui-registry/registry/ai-chat-window/src/ai-chat-window.preview.tsx
@@ -1,0 +1,39 @@
+import { useState } from "react";
+import { AIChatWindow, type AIChatMessage } from "./ai-chat-window";
+
+const initialMessages: AIChatMessage[] = [
+  {
+    id: "1",
+    role: "assistant",
+    content: "Hello! I'm your AI teammate. Ask me anything about your product.",
+  },
+  {
+    id: "2",
+    role: "user",
+    content: "Give me three onboarding ideas for new users.",
+  },
+  {
+    id: "3",
+    role: "assistant",
+    content: "Sure! Here's a quick plan to get people activated...",
+  },
+];
+
+export default function AIChatWindowPreview() {
+  const [messages, setMessages] = useState(initialMessages);
+
+  async function handleSend(message: string) {
+    const userMessage: AIChatMessage = {
+      id: String(Date.now()),
+      role: "user",
+      content: message,
+    };
+    setMessages((current) => [...current, userMessage]);
+  }
+
+  return (
+    <div className="h-[500px] w-full max-w-lg">
+      <AIChatWindow messages={messages} onSendMessage={handleSend} emptyState="Start the conversation" />
+    </div>
+  );
+}

--- a/ui-registry/registry/ai-chat-window/src/ai-chat-window.tsx
+++ b/ui-registry/registry/ai-chat-window/src/ai-chat-window.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { FormEvent, useEffect, useRef, useState, type ReactNode } from "react";
+import { Loader2, Send } from "lucide-react";
+
+type MessageRole = "user" | "assistant" | "system";
+
+export interface AIChatMessage {
+  id: string;
+  role: MessageRole;
+  content: string;
+  timestamp?: string;
+}
+
+export interface AIChatWindowProps {
+  messages: AIChatMessage[];
+  onSendMessage?: (message: string) => Promise<void> | void;
+  isStreaming?: boolean;
+  title?: string;
+  inputPlaceholder?: string;
+  disabled?: boolean;
+  emptyState?: ReactNode;
+}
+
+const roleLabels: Record<MessageRole, string> = {
+  assistant: "Assistant",
+  system: "System",
+  user: "You",
+};
+
+function bubbleClasses(role: MessageRole) {
+  if (role === "assistant") {
+    return "bg-muted text-foreground border";
+  }
+  if (role === "system") {
+    return "bg-secondary/40 text-secondary-foreground border";
+  }
+  return "bg-primary text-primary-foreground";
+}
+
+export function AIChatWindow({
+  messages,
+  onSendMessage,
+  isStreaming = false,
+  title = "AI Assistant",
+  inputPlaceholder = "Ask a question...",
+  disabled = false,
+  emptyState,
+}: AIChatWindowProps) {
+  const formRef = useRef<HTMLFormElement | null>(null);
+  const listRef = useRef<HTMLDivElement | null>(null);
+  const [draft, setDraft] = useState("");
+  const isInputDisabled = disabled || isStreaming || !onSendMessage;
+
+  useEffect(() => {
+    const list = listRef.current;
+    if (!list) return;
+    list.scrollTo({ top: list.scrollHeight, behavior: "smooth" });
+  }, [messages]);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!draft.trim() || !onSendMessage) return;
+    const value = draft.trim();
+    setDraft("");
+    await onSendMessage(value);
+    formRef.current?.reset();
+  }
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden rounded-lg border bg-background shadow-sm">
+      <div className="flex items-center justify-between border-b px-4 py-3">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+          {title}
+        </h2>
+        {isStreaming ? (
+          <span className="inline-flex items-center gap-2 text-xs text-muted-foreground">
+            <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
+            Responding...
+          </span>
+        ) : null}
+      </div>
+      <div
+        ref={listRef}
+        className="flex-1 space-y-4 overflow-y-auto bg-muted/20 px-4 py-6"
+        role="log"
+        aria-live="polite"
+      >
+        {messages.length === 0 && emptyState ? (
+          <div className="text-center text-sm text-muted-foreground">{emptyState}</div>
+        ) : null}
+        {messages.map((message) => (
+          <article
+            key={message.id}
+            className="flex flex-col gap-2"
+            aria-label={`${roleLabels[message.role]} message`}
+          >
+            <div className="flex items-center gap-2 text-xs uppercase tracking-wide text-muted-foreground">
+              <span>{roleLabels[message.role]}</span>
+              {message.timestamp ? <time dateTime={message.timestamp}>{message.timestamp}</time> : null}
+            </div>
+            <div
+              className={`max-w-[85%] rounded-2xl px-4 py-3 text-sm leading-relaxed shadow ${bubbleClasses(message.role)}`}
+            >
+              {message.content}
+            </div>
+          </article>
+        ))}
+      </div>
+      <form
+        ref={formRef}
+        onSubmit={handleSubmit}
+        className="border-t bg-background px-4 py-3"
+        aria-label="Send a message"
+      >
+        <label className="sr-only" htmlFor="ai-chat-input">
+          Message
+        </label>
+        <div className="flex items-center gap-2 rounded-full border px-3 py-2 shadow-sm">
+          <textarea
+            id="ai-chat-input"
+            name="message"
+            rows={1}
+            value={draft}
+            onChange={(event) => setDraft(event.target.value)}
+            placeholder={inputPlaceholder}
+            className="w-full resize-none bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+            autoComplete="off"
+            disabled={isInputDisabled}
+            aria-disabled={isInputDisabled}
+          />
+          <button
+            type="submit"
+            className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-primary text-primary-foreground transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+            disabled={isInputDisabled || !draft.trim()}
+          >
+            {isStreaming ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}
+            <span className="sr-only">Send message</span>
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+export default AIChatWindow;

--- a/ui-registry/registry/ai-input/meta.json
+++ b/ui-registry/registry/ai-input/meta.json
@@ -1,0 +1,27 @@
+{
+  "id": "ai-input",
+  "name": "AI Input",
+  "type": "component",
+  "categories": ["ai", "form"],
+  "description": "Message composer with optional voice trigger and async submit handler.",
+  "files": [
+    {
+      "src": "src/ai-input.tsx",
+      "dest": "components/ai/input.tsx",
+      "type": "component"
+    }
+  ],
+  "preview": {
+    "src": "src/ai-input.preview.tsx"
+  },
+  "dependencies": [
+    "lucide-react"
+  ],
+  "peerDependencies": {
+    "react": ">=18.2.0"
+  },
+  "license": {
+    "type": "MIT",
+    "url": "https://opensource.org/licenses/MIT"
+  }
+}

--- a/ui-registry/registry/ai-input/src/ai-input.preview.tsx
+++ b/ui-registry/registry/ai-input/src/ai-input.preview.tsx
@@ -1,0 +1,27 @@
+import { useState } from "react";
+import { AIInput } from "./ai-input";
+
+export default function AIInputPreview() {
+  const [log, setLog] = useState<string[]>([]);
+
+  async function handleSubmit(value: string) {
+    setLog((items) => [value, ...items].slice(0, 3));
+  }
+
+  return (
+    <div className="space-y-4">
+      <AIInput onSubmit={handleSubmit} placeholder="Summarise the weekly report" />
+      <div className="rounded-md border bg-muted/40 p-3 text-xs text-muted-foreground">
+        <p className="mb-2 font-medium uppercase tracking-wide">Last messages</p>
+        <ul className="space-y-1">
+          {log.length === 0 ? <li>No messages yet.</li> : null}
+          {log.map((value, index) => (
+            <li key={`${value}-${index}`} className="truncate">
+              {value}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/ui-registry/registry/ai-input/src/ai-input.tsx
+++ b/ui-registry/registry/ai-input/src/ai-input.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { FormEvent, useState } from "react";
+import { Loader2, Mic, Send } from "lucide-react";
+
+export interface AIInputProps {
+  placeholder?: string;
+  onSubmit?: (value: string) => Promise<void> | void;
+  onVoiceRequest?: () => Promise<void> | void;
+  autoFocus?: boolean;
+  isLoading?: boolean;
+  disabled?: boolean;
+}
+
+export function AIInput({
+  placeholder = "Type a message...",
+  onSubmit,
+  onVoiceRequest,
+  autoFocus,
+  isLoading = false,
+  disabled = false,
+}: AIInputProps) {
+  const [value, setValue] = useState("");
+  const isDisabled = disabled || isLoading;
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!onSubmit || !value.trim()) return;
+    const nextValue = value.trim();
+    setValue("");
+    await onSubmit(nextValue);
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="flex items-end gap-2 rounded-2xl border bg-background px-4 py-3 shadow-sm"
+    >
+      <textarea
+        name="message"
+        value={value}
+        onChange={(event) => setValue(event.target.value)}
+        placeholder={placeholder}
+        rows={1}
+        autoFocus={autoFocus}
+        disabled={isDisabled}
+        className="min-h-[40px] w-full resize-none bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+      />
+      <div className="flex items-center gap-1">
+        {onVoiceRequest ? (
+          <button
+            type="button"
+            onClick={() => onVoiceRequest?.()}
+            className="inline-flex h-10 w-10 items-center justify-center rounded-full text-muted-foreground transition hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+            disabled={isDisabled}
+          >
+            <Mic className="h-4 w-4" />
+            <span className="sr-only">Start voice input</span>
+          </button>
+        ) : null}
+        <button
+          type="submit"
+          className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-primary text-primary-foreground transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+          disabled={isDisabled || !value.trim()}
+        >
+          {isLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}
+          <span className="sr-only">Send message</span>
+        </button>
+      </div>
+    </form>
+  );
+}
+
+export default AIInput;

--- a/ui-registry/registry/ai-message-list/meta.json
+++ b/ui-registry/registry/ai-message-list/meta.json
@@ -1,0 +1,25 @@
+{
+  "id": "ai-message-list",
+  "name": "AI Message List",
+  "type": "component",
+  "categories": ["ai", "chat"],
+  "description": "Stacked chat bubble list with sensible defaults and empty state messaging.",
+  "files": [
+    {
+      "src": "src/ai-message-list.tsx",
+      "dest": "components/ai/message-list.tsx",
+      "type": "component"
+    }
+  ],
+  "preview": {
+    "src": "src/ai-message-list.preview.tsx"
+  },
+  "dependencies": [],
+  "peerDependencies": {
+    "react": ">=18.2.0"
+  },
+  "license": {
+    "type": "MIT",
+    "url": "https://opensource.org/licenses/MIT"
+  }
+}

--- a/ui-registry/registry/ai-message-list/src/ai-message-list.preview.tsx
+++ b/ui-registry/registry/ai-message-list/src/ai-message-list.preview.tsx
@@ -1,0 +1,27 @@
+import { AIMessageList, type AIMessageItem } from "./ai-message-list";
+
+const demoMessages: AIMessageItem[] = [
+  {
+    id: "1",
+    role: "assistant",
+    content: "How can I help you ship faster today?",
+  },
+  {
+    id: "2",
+    role: "user",
+    content: "Summarise the latest changelog into a tweet.",
+  },
+  {
+    id: "3",
+    role: "assistant",
+    content: "Absolutely! Here's a concise update...",
+  },
+];
+
+export default function AIMessageListPreview() {
+  return (
+    <div className="rounded-lg border bg-background p-6">
+      <AIMessageList messages={demoMessages} />
+    </div>
+  );
+}

--- a/ui-registry/registry/ai-message-list/src/ai-message-list.tsx
+++ b/ui-registry/registry/ai-message-list/src/ai-message-list.tsx
@@ -1,0 +1,51 @@
+import { forwardRef } from "react";
+
+export type MessageRole = "user" | "assistant" | "system";
+
+export interface AIMessageItem {
+  id: string;
+  role: MessageRole;
+  content: string;
+  status?: "streaming" | "complete";
+}
+
+export interface AIMessageListProps {
+  messages: AIMessageItem[];
+  className?: string;
+}
+
+const roleStyles: Record<MessageRole, string> = {
+  assistant: "bg-muted text-muted-foreground border",
+  user: "bg-primary text-primary-foreground",
+  system: "bg-secondary/30 text-secondary-foreground border",
+};
+
+export const AIMessageList = forwardRef<HTMLDivElement, AIMessageListProps>(
+  ({ messages, className }, ref) => {
+    return (
+      <div ref={ref} className={`space-y-4 ${className ?? ""}`}>
+        {messages.map((message) => (
+          <div key={message.id} className="flex flex-col gap-2 text-sm">
+            <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              {message.role === "assistant" && "Assistant"}
+              {message.role === "user" && "You"}
+              {message.role === "system" && "System"}
+            </span>
+            <div className={`max-w-[85%] rounded-2xl px-4 py-3 shadow ${roleStyles[message.role]}`}>
+              {message.content}
+            </div>
+          </div>
+        ))}
+        {messages.length === 0 ? (
+          <div className="rounded-lg border border-dashed px-4 py-8 text-center text-sm text-muted-foreground">
+            Ask a question to get started.
+          </div>
+        ) : null}
+      </div>
+    );
+  }
+);
+
+AIMessageList.displayName = "AIMessageList";
+
+export default AIMessageList;

--- a/ui-registry/registry/auth-dropdown/meta.json
+++ b/ui-registry/registry/auth-dropdown/meta.json
@@ -1,0 +1,28 @@
+{
+  "id": "auth-dropdown",
+  "name": "Auth Dropdown",
+  "type": "component",
+  "categories": ["authentication", "navigation"],
+  "description": "Profile dropdown with avatar, account actions, and sign-out control.",
+  "files": [
+    {
+      "src": "src/auth-dropdown.tsx",
+      "dest": "components/auth-dropdown.tsx",
+      "type": "component"
+    }
+  ],
+  "preview": {
+    "src": "src/auth-dropdown.preview.tsx"
+  },
+  "dependencies": [
+    "lucide-react"
+  ],
+  "peerDependencies": {
+    "react": ">=18.2.0",
+    "next": ">=13.4.0"
+  },
+  "license": {
+    "type": "MIT",
+    "url": "https://opensource.org/licenses/MIT"
+  }
+}

--- a/ui-registry/registry/auth-dropdown/src/auth-dropdown.preview.tsx
+++ b/ui-registry/registry/auth-dropdown/src/auth-dropdown.preview.tsx
@@ -1,0 +1,30 @@
+import { useState } from "react";
+import { AuthDropdown } from "./auth-dropdown";
+
+export default function AuthDropdownPreview() {
+  const [eventLog, setEventLog] = useState<string[]>([]);
+
+  function addLog(entry: string) {
+    setEventLog((logs) => [entry, ...logs].slice(0, 3));
+  }
+
+  return (
+    <div className="space-y-4">
+      <AuthDropdown
+        userName="Ada Lovelace"
+        userEmail="ada@lovelabs.io"
+        onManageAccount={() => addLog("Manage account clicked")}
+        onSignOut={() => addLog("Sign out clicked")}
+      />
+      <div className="rounded-md border bg-muted/40 p-3 text-xs text-muted-foreground">
+        <p className="mb-2 font-semibold uppercase tracking-wide">Activity</p>
+        <ul className="space-y-1">
+          {eventLog.length === 0 ? <li>No actions yet.</li> : null}
+          {eventLog.map((item, index) => (
+            <li key={`${item}-${index}`}>{item}</li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/ui-registry/registry/auth-dropdown/src/auth-dropdown.tsx
+++ b/ui-registry/registry/auth-dropdown/src/auth-dropdown.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import Image from "next/image";
+import { ChevronDown, LogOut, Settings } from "lucide-react";
+
+export interface AuthDropdownProps {
+  userName: string;
+  userEmail?: string;
+  avatarUrl?: string;
+  onManageAccount?: () => void;
+  onSignOut?: () => void;
+}
+
+export function AuthDropdown({
+  userName,
+  userEmail,
+  avatarUrl,
+  onManageAccount,
+  onSignOut,
+}: AuthDropdownProps) {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    function handleClick(event: MouseEvent) {
+      if (!containerRef.current?.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    }
+
+    if (open) {
+      window.addEventListener("click", handleClick);
+    }
+    return () => window.removeEventListener("click", handleClick);
+  }, [open]);
+
+  return (
+    <div ref={containerRef} className="relative inline-flex">
+      <button
+        type="button"
+        className="inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-sm font-medium shadow-sm transition hover:bg-muted"
+        onClick={() => setOpen((state) => !state)}
+        aria-haspopup="menu"
+        aria-expanded={open}
+      >
+        <span className="flex h-8 w-8 items-center justify-center overflow-hidden rounded-full bg-muted">
+          {avatarUrl ? (
+            <Image src={avatarUrl} alt={userName} width={32} height={32} className="h-8 w-8 object-cover" />
+          ) : (
+            <span className="text-sm font-semibold uppercase text-muted-foreground">
+              {userName.slice(0, 2)}
+            </span>
+          )}
+        </span>
+        <span className="hidden text-left text-sm leading-tight sm:block">
+          <span className="block font-semibold">{userName}</span>
+          {userEmail ? <span className="text-xs text-muted-foreground">{userEmail}</span> : null}
+        </span>
+        <ChevronDown className="h-4 w-4 text-muted-foreground" />
+      </button>
+      {open ? (
+        <div
+          role="menu"
+          className="absolute right-0 top-12 z-20 w-56 overflow-hidden rounded-xl border bg-background shadow-lg"
+        >
+          <div className="border-b px-4 py-3 text-sm">
+            <p className="font-semibold">{userName}</p>
+            {userEmail ? <p className="text-xs text-muted-foreground">{userEmail}</p> : null}
+          </div>
+          <div className="p-2 text-sm">
+            <button
+              type="button"
+              role="menuitem"
+              onClick={() => {
+                onManageAccount?.();
+                setOpen(false);
+              }}
+              className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left transition hover:bg-muted"
+            >
+              <Settings className="h-4 w-4" /> Manage account
+            </button>
+            <button
+              type="button"
+              role="menuitem"
+              onClick={() => {
+                onSignOut?.();
+                setOpen(false);
+              }}
+              className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-red-600 transition hover:bg-red-50"
+            >
+              <LogOut className="h-4 w-4" /> Sign out
+            </button>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export default AuthDropdown;

--- a/ui-registry/registry/command-menu/meta.json
+++ b/ui-registry/registry/command-menu/meta.json
@@ -1,0 +1,28 @@
+{
+  "id": "command-menu",
+  "name": "Command Menu",
+  "type": "component",
+  "categories": ["navigation"],
+  "description": "Command palette powered by cmdk with keyboard shortcut support.",
+  "files": [
+    {
+      "src": "src/command-menu.tsx",
+      "dest": "components/command-menu.tsx",
+      "type": "component"
+    }
+  ],
+  "preview": {
+    "src": "src/command-menu.preview.tsx"
+  },
+  "dependencies": [
+    "cmdk",
+    "lucide-react"
+  ],
+  "peerDependencies": {
+    "react": ">=18.2.0"
+  },
+  "license": {
+    "type": "MIT",
+    "url": "https://opensource.org/licenses/MIT"
+  }
+}

--- a/ui-registry/registry/command-menu/src/command-menu.preview.tsx
+++ b/ui-registry/registry/command-menu/src/command-menu.preview.tsx
@@ -1,0 +1,45 @@
+import { useState } from "react";
+import { CommandMenu, type CommandMenuItem } from "./command-menu";
+
+const demoCommands: CommandMenuItem[] = [
+  {
+    id: "open-docs",
+    title: "Open documentation",
+    description: "Visit the internal knowledge base",
+    shortcut: "⇧⌘D",
+    group: "Navigation",
+    onSelect: () => alert("Navigate to docs"),
+  },
+  {
+    id: "create-issue",
+    title: "Create GitHub issue",
+    description: "Open a new bug report in the tracker",
+    shortcut: "⇧⌘I",
+    group: "Actions",
+    onSelect: () => alert("Issue modal opened"),
+  },
+  {
+    id: "invite-teammate",
+    title: "Invite teammate",
+    description: "Generate an invite link",
+    shortcut: "⌘I",
+    group: "Actions",
+    onSelect: () => alert("Invite flow launched"),
+  },
+];
+
+export default function CommandMenuPreview() {
+  const [message, setMessage] = useState("Trigger a command to see feedback here.");
+
+  const commands = demoCommands.map((command) => ({
+    ...command,
+    onSelect: () => setMessage(`Command executed: ${command.title}`),
+  }));
+
+  return (
+    <div className="space-y-4">
+      <CommandMenu items={commands} />
+      <div className="rounded-lg border bg-muted/30 p-4 text-sm text-muted-foreground">{message}</div>
+    </div>
+  );
+}

--- a/ui-registry/registry/command-menu/src/command-menu.tsx
+++ b/ui-registry/registry/command-menu/src/command-menu.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Command } from "cmdk";
+import { Search } from "lucide-react";
+
+export interface CommandMenuItem {
+  id: string;
+  title: string;
+  shortcut?: string;
+  onSelect: () => void;
+  group?: string;
+  description?: string;
+}
+
+export interface CommandMenuProps {
+  items: CommandMenuItem[];
+  placeholder?: string;
+  searchEmptyState?: string;
+}
+
+function groupItems(items: CommandMenuItem[]) {
+  return items.reduce<Record<string, CommandMenuItem[]>>((groups, item) => {
+    const key = item.group ?? "Commands";
+    if (!groups[key]) {
+      groups[key] = [];
+    }
+    groups[key].push(item);
+    return groups;
+  }, {});
+}
+
+export function CommandMenu({
+  items,
+  placeholder = "Type a command...",
+  searchEmptyState = "No commands found",
+}: CommandMenuProps) {
+  const [open, setOpen] = useState(false);
+  const [value, setValue] = useState("");
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    function handleKeydown(event: KeyboardEvent) {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
+        event.preventDefault();
+        setOpen((state) => !state);
+      }
+    }
+
+    window.addEventListener("keydown", handleKeydown);
+    return () => window.removeEventListener("keydown", handleKeydown);
+  }, []);
+
+  useEffect(() => {
+    if (open) {
+      const timer = setTimeout(() => inputRef.current?.focus(), 0);
+      return () => clearTimeout(timer);
+    }
+    return undefined;
+  }, [open]);
+
+  const grouped = groupItems(items);
+
+  return (
+    <>
+      <button
+        type="button"
+        className="inline-flex items-center gap-2 rounded-full border px-3 py-2 text-sm text-muted-foreground shadow-sm transition hover:bg-muted"
+        onClick={() => setOpen(true)}
+      >
+        <Search className="h-4 w-4" />
+        <span>Search commands</span>
+        <kbd className="ml-2 hidden rounded border bg-muted px-2 py-1 text-[10px] font-medium uppercase text-muted-foreground sm:inline">
+          ⌘K
+        </kbd>
+      </button>
+      <Command.Dialog open={open} onOpenChange={setOpen} label="Global command menu">
+        <div className="fixed inset-0 z-50 flex items-start justify-center bg-background/80 p-4 backdrop-blur-sm">
+          <div className="w-full max-w-xl overflow-hidden rounded-2xl border bg-background shadow-xl">
+            <Command className="flex h-full max-h-[500px] flex-col">
+              <div className="flex items-center gap-2 border-b px-4 py-3">
+                <Search className="h-4 w-4 text-muted-foreground" />
+                <Command.Input
+                  ref={inputRef}
+                  value={value}
+                  onValueChange={setValue}
+                  placeholder={placeholder}
+                  className="flex-1 bg-transparent text-sm outline-none"
+                />
+                {value ? (
+                  <button
+                    type="button"
+                    onClick={() => setValue("")}
+                    className="text-xs text-muted-foreground transition hover:text-foreground"
+                  >
+                    Clear
+                  </button>
+                ) : null}
+              </div>
+              <Command.List className="flex-1 overflow-y-auto px-2 py-2 text-sm">
+                <Command.Empty className="py-10 text-center text-muted-foreground">
+                  {searchEmptyState}
+                </Command.Empty>
+                {Object.entries(grouped).map(([groupName, groupItems]) => (
+                  <Command.Group key={groupName} heading={groupName} className="space-y-1">
+                    {groupItems.map((item) => (
+                      <Command.Item
+                        key={item.id}
+                        value={item.title}
+                        onSelect={() => {
+                          item.onSelect();
+                          setOpen(false);
+                        }}
+                        className="flex cursor-pointer items-center justify-between rounded-lg px-3 py-2 text-sm outline-none data-[selected=true]:bg-muted data-[selected=true]:text-foreground"
+                      >
+                        <div>
+                          <div className="font-medium">{item.title}</div>
+                          {item.description ? (
+                            <p className="text-xs text-muted-foreground">{item.description}</p>
+                          ) : null}
+                        </div>
+                        {item.shortcut ? (
+                          <kbd className="rounded border bg-muted px-2 py-1 text-[10px] font-medium uppercase text-muted-foreground">
+                            {item.shortcut}
+                          </kbd>
+                        ) : null}
+                      </Command.Item>
+                    ))}
+                  </Command.Group>
+                ))}
+              </Command.List>
+            </Command>
+          </div>
+        </div>
+      </Command.Dialog>
+    </>
+  );
+}
+
+export default CommandMenu;

--- a/ui-registry/registry/index.json
+++ b/ui-registry/registry/index.json
@@ -1,0 +1,48 @@
+{
+  "registry": "private-ui",
+  "version": 1,
+  "items": [
+    {
+      "id": "ai-chat-window",
+      "name": "AI Chat Window",
+      "type": "component",
+      "categories": ["ai", "chat"],
+      "meta": "./ai-chat-window/meta.json"
+    },
+    {
+      "id": "ai-message-list",
+      "name": "AI Message List",
+      "type": "component",
+      "categories": ["ai", "chat"],
+      "meta": "./ai-message-list/meta.json"
+    },
+    {
+      "id": "ai-input",
+      "name": "AI Input",
+      "type": "component",
+      "categories": ["ai", "form"],
+      "meta": "./ai-input/meta.json"
+    },
+    {
+      "id": "command-menu",
+      "name": "Command Menu",
+      "type": "component",
+      "categories": ["navigation"],
+      "meta": "./command-menu/meta.json"
+    },
+    {
+      "id": "pricing-card",
+      "name": "Pricing Card",
+      "type": "component",
+      "categories": ["marketing"],
+      "meta": "./pricing-card/meta.json"
+    },
+    {
+      "id": "auth-dropdown",
+      "name": "Auth Dropdown",
+      "type": "component",
+      "categories": ["authentication", "navigation"],
+      "meta": "./auth-dropdown/meta.json"
+    }
+  ]
+}

--- a/ui-registry/registry/pricing-card/meta.json
+++ b/ui-registry/registry/pricing-card/meta.json
@@ -1,0 +1,27 @@
+{
+  "id": "pricing-card",
+  "name": "Pricing Card",
+  "type": "component",
+  "categories": ["marketing"],
+  "description": "Flexible pricing card with feature list, CTA button, and highlight state.",
+  "files": [
+    {
+      "src": "src/pricing-card.tsx",
+      "dest": "components/pricing-card.tsx",
+      "type": "component"
+    }
+  ],
+  "preview": {
+    "src": "src/pricing-card.preview.tsx"
+  },
+  "dependencies": [
+    "lucide-react"
+  ],
+  "peerDependencies": {
+    "react": ">=18.2.0"
+  },
+  "license": {
+    "type": "MIT",
+    "url": "https://opensource.org/licenses/MIT"
+  }
+}

--- a/ui-registry/registry/pricing-card/src/pricing-card.preview.tsx
+++ b/ui-registry/registry/pricing-card/src/pricing-card.preview.tsx
@@ -1,0 +1,31 @@
+import { PricingCard } from "./pricing-card";
+
+const features = [
+  { id: "unlimited", label: "Unlimited projects" },
+  { id: "analytics", label: "Advanced analytics" },
+  { id: "support", label: "Priority support" },
+  { id: "ai", label: "AI-powered insights" },
+];
+
+export default function PricingCardPreview() {
+  return (
+    <div className="grid gap-6 md:grid-cols-2">
+      <PricingCard
+        name="Pro"
+        price="$29/mo"
+        description="For product teams shipping production apps."
+        features={features}
+        ctaLabel="Start free trial"
+        highlight
+        footer={<p className="text-xs text-muted-foreground">No credit card required.</p>}
+      />
+      <PricingCard
+        name="Starter"
+        price="$12/mo"
+        description="Great for small teams exploring AI workflows."
+        features={features.slice(0, 3)}
+        ctaLabel="Choose plan"
+      />
+    </div>
+  );
+}

--- a/ui-registry/registry/pricing-card/src/pricing-card.tsx
+++ b/ui-registry/registry/pricing-card/src/pricing-card.tsx
@@ -1,0 +1,66 @@
+import type { ReactNode } from "react";
+import { Check, Zap } from "lucide-react";
+
+export interface PricingCardFeature {
+  id: string;
+  label: string;
+}
+
+export interface PricingCardProps {
+  name: string;
+  price: string;
+  description?: string;
+  features: PricingCardFeature[];
+  ctaLabel: string;
+  onCtaClick?: () => void;
+  highlight?: boolean;
+  footer?: ReactNode;
+}
+
+export function PricingCard({
+  name,
+  price,
+  description,
+  features,
+  ctaLabel,
+  onCtaClick,
+  highlight = false,
+  footer,
+}: PricingCardProps) {
+  return (
+    <div
+      className={`flex h-full flex-col justify-between rounded-3xl border bg-background p-8 shadow-sm transition hover:-translate-y-1 hover:shadow-lg ${highlight ? "border-primary shadow-md" : ""}`}
+    >
+      <div className="space-y-4">
+        <div className="inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          {highlight ? <Zap className="h-3.5 w-3.5 text-primary" /> : null}
+          {name}
+        </div>
+        <div>
+          <p className="text-4xl font-bold">{price}</p>
+          {description ? <p className="mt-2 text-sm text-muted-foreground">{description}</p> : null}
+        </div>
+        <ul className="space-y-3 text-sm">
+          {features.map((feature) => (
+            <li key={feature.id} className="flex items-start gap-2">
+              <Check className="mt-0.5 h-4 w-4 text-primary" />
+              <span>{feature.label}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+      <div className="mt-8 space-y-4">
+        <button
+          type="button"
+          onClick={onCtaClick}
+          className={`inline-flex w-full items-center justify-center rounded-full px-5 py-3 text-sm font-semibold transition ${highlight ? "bg-primary text-primary-foreground hover:bg-primary/90" : "bg-muted text-foreground hover:bg-muted/80"}`}
+        >
+          {ctaLabel}
+        </button>
+        {footer}
+      </div>
+    </div>
+  );
+}
+
+export default PricingCard;


### PR DESCRIPTION
## Summary
- add a private shadcn-compatible registry with six AI-focused components and previews
- scaffold a Next.js gallery app with filtering, collections, and an export workflow wired to the CLI
- implement a reusable export CLI script plus API route for downloading generated bundles

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8182bf21c8329bbd6b5525828f343

## Summary by Sourcery

Introduce a private shadcn-compatible component registry alongside a Next.js gallery application that lets users browse, filter, save collections, and export selected components into a fresh project bundle.

New Features:
- Add a private shadcn-compatible registry with six AI-focused components, preview modules, and metadata files
- Create a Next.js gallery app for loading registry items with search, category facets, and selection context
- Embed UI controls for saving custom collections and triggering exports from within the gallery
- Implement a reusable export CLI script and server action that scaffolds a new Next.js app via the shadcn CLI, installs chosen components, generates license summaries and README, and optionally zips the output
- Provide an API route to serve the generated export ZIP archive for download

Enhancements:
- Configure TypeScript path aliases for the registry and enable Next.js experimental typedRoutes and externalDir
- Set up Tailwind CSS, project scripts, and dynamic component previews via Next.js dynamic imports

Documentation:
- Add README files for the gallery application and the private registry explaining setup and usage.